### PR TITLE
Fix hydration effect initialization order

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -146,37 +146,6 @@ function App() {
     }
   }, [webhookUrl]);
 
-  useEffect(() => {
-    if (!isAuthenticated || hydrationAttemptedRef.current) {
-      return;
-    }
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    hydrationAttemptedRef.current = true;
-    const params = new URLSearchParams(window.location.search);
-    let candidate = params.get('job');
-    if (!candidate) {
-      try {
-        candidate = window.localStorage.getItem('aci-active-job-id') || '';
-      } catch (error) {
-        console.warn('Não foi possível recuperar o job ativo armazenado.', error);
-      }
-    }
-
-    if (candidate) {
-      hydrateJobFromServer(candidate).catch((error) => {
-        console.warn('Falha ao hidratar job existente:', error);
-        setStatusBanner({ type: 'error', message: error.message || 'Não foi possível recuperar o job informado.' });
-        setActiveShareLink(null);
-        updateJobReference(null);
-      });
-    } else {
-      setActiveShareLink(null);
-    }
-  }, [hydrateJobFromServer, isAuthenticated, updateJobReference]);
-
   const closeEventSource = useCallback(() => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -437,6 +406,37 @@ function App() {
       setIsHydratingJob(false);
     }
   }, [registerHistoryEntry, subscribeToJob, updateJobReference]);
+
+  useEffect(() => {
+    if (!isAuthenticated || hydrationAttemptedRef.current) {
+      return;
+    }
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    hydrationAttemptedRef.current = true;
+    const params = new URLSearchParams(window.location.search);
+    let candidate = params.get('job');
+    if (!candidate) {
+      try {
+        candidate = window.localStorage.getItem('aci-active-job-id') || '';
+      } catch (error) {
+        console.warn('Não foi possível recuperar o job ativo armazenado.', error);
+      }
+    }
+
+    if (candidate) {
+      hydrateJobFromServer(candidate).catch((error) => {
+        console.warn('Falha ao hidratar job existente:', error);
+        setStatusBanner({ type: 'error', message: error.message || 'Não foi possível recuperar o job informado.' });
+        setActiveShareLink(null);
+        updateJobReference(null);
+      });
+    } else {
+      setActiveShareLink(null);
+    }
+  }, [hydrateJobFromServer, isAuthenticated, updateJobReference]);
 
   const handleSubmit = useCallback(async (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- move the job hydration side-effect to run after the helper is declared so it is available during render
- keep the synchronization logic intact while preventing runtime ReferenceErrors that blank the UI

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e679c56a188324ade6727063c95b06