### PR TITLE
Adjust workspace layout responsiveness

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -131,7 +131,7 @@ a {
 
 .workspace {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: minmax(340px, 380px) minmax(0, 1fr);
   gap: 32px;
   align-items: flex-start;
 }
@@ -910,7 +910,7 @@ button:disabled {
   }
 }
 
-@media (max-width: 1080px) {
+@media (max-width: 960px) {
   .workspace {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- adjust the workspace grid columns to keep the side panel width flexible across devices
- lower the breakpoint that stacks the workspace so medium-width screens keep the same two-column layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e688be098c83249e76fd41fe1f5fba