### PR TITLE
Revamp dashboard layout with textured background

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -20,6 +20,9 @@
   --muted: rgba(255, 255, 255, 0.04);
   --shadow-lg: 0 28px 80px rgba(2, 4, 20, 0.55);
   --shadow-md: 0 18px 45px rgba(2, 4, 20, 0.45);
+  --layout-max-width: 1640px;
+  --layout-side-padding: clamp(24px, 5vw, 56px);
+  --texture-opacity: 0.16;
 }
 
 *, *::before, *::after {
@@ -32,8 +35,21 @@ body {
   font-family: 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
   background: var(--bg-primary);
   color: var(--text-primary);
-  display: flex;
-  justify-content: center;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url('./assets/cs2-pattern.svg');
+  background-size: 220px 220px;
+  background-repeat: repeat;
+  opacity: var(--texture-opacity);
+  pointer-events: none;
+  mix-blend-mode: lighten;
+  z-index: 0;
 }
 
 a {
@@ -41,11 +57,14 @@ a {
 }
 
 .app-shell {
-  width: min(1280px, 96%);
-  margin: 48px auto 64px;
+  width: min(var(--layout-max-width), calc(100% - 2 * var(--layout-side-padding)));
+  margin: 48px auto 80px;
+  padding: 0 var(--layout-side-padding);
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 56px;
+  position: relative;
+  z-index: 1;
 }
 
 .hero {
@@ -53,10 +72,13 @@ a {
   overflow: hidden;
   background: rgba(10, 12, 32, 0.78);
   border: 1px solid var(--surface-border);
-  border-radius: 28px;
-  padding: 40px 48px;
+  border-radius: 32px;
+  padding: 56px clamp(40px, 5vw, 64px);
   backdrop-filter: blur(26px);
   box-shadow: var(--shadow-lg);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 36px;
 }
 
 .hero::before {
@@ -89,16 +111,17 @@ a {
 
 .hero-content h1 {
   font-family: 'Space Grotesk', 'Inter', sans-serif;
-  font-size: clamp(2.6rem, 4vw, 3.2rem);
-  margin: 0 0 12px;
-  letter-spacing: 0.05em;
+  font-size: clamp(2.7rem, 4vw, 3.6rem);
+  margin: 0 0 18px;
+  letter-spacing: 0.06em;
 }
 
 .hero-content p {
-  margin: 0 0 18px;
+  margin: 0 0 22px;
   color: var(--text-secondary);
-  font-size: 1.05rem;
-  max-width: 780px;
+  font-size: 1.08rem;
+  max-width: 720px;
+  line-height: 1.7;
 }
 
 .hero-highlights {
@@ -106,7 +129,7 @@ a {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 12px;
+  gap: 18px;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
@@ -131,16 +154,23 @@ a {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(340px, 380px) minmax(0, 1fr);
-  gap: 32px;
+  grid-template-columns: minmax(360px, 420px) minmax(0, 1fr);
+  gap: 40px;
   align-items: flex-start;
+}
+
+.control-column,
+.output-column {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
 .surface {
   background: var(--surface);
   border: 1px solid var(--surface-border);
-  border-radius: 24px;
-  padding: 32px;
+  border-radius: 26px;
+  padding: 36px;
   box-shadow: var(--shadow-md);
   transition: background 0.2s ease, transform 0.2s ease;
 }
@@ -178,7 +208,7 @@ a {
 .control-form {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 22px;
 }
 
 .field-label {
@@ -910,27 +940,51 @@ button:disabled {
   }
 }
 
-@media (max-width: 960px) {
+@media (max-width: 1280px) {
+  .workspace {
+    grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 1024px) {
   .workspace {
     grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .control-column,
+  .output-column {
+    gap: 28px;
+  }
+
+  .hero {
+    padding: 48px clamp(28px, 6vw, 52px);
   }
 
   .surface {
-    padding: 28px;
+    padding: 32px;
   }
 
-  .log-stream {
-    max-height: 360px;
+  body::before {
+    background-size: 180px 180px;
   }
 }
 
 @media (max-width: 720px) {
   .app-shell {
-    margin: 32px auto 48px;
+    margin: 36px auto 56px;
+    padding: 0 clamp(18px, 5vw, 28px);
+    gap: 44px;
   }
 
   .hero {
-    padding: 32px 28px;
+    border-radius: 28px;
+    padding: 40px 28px;
+    gap: 28px;
+  }
+
+  .hero-highlights {
+    grid-template-columns: 1fr;
   }
 
   .button-row {
@@ -946,6 +1000,14 @@ button:disabled {
     margin-top: 8px;
   }
 
+  .log-header {
+    flex-direction: column;
+  }
+
+  .log-header-tools {
+    justify-content: flex-start;
+  }
+
   .history-header {
     flex-direction: column;
     align-items: stretch;
@@ -959,7 +1021,27 @@ button:disabled {
     width: 100%;
   }
 
-  .history-frame iframe {
+  .history-frame iframe,
+  .report-frame {
     height: 260px;
+  }
+}
+
+@media (max-width: 540px) {
+  .surface {
+    padding: 28px;
+  }
+
+  textarea {
+    min-height: 200px;
+  }
+
+  body::before {
+    background-size: 140px 140px;
+    opacity: 0.12;
+  }
+
+  .log-stream {
+    max-height: 320px;
   }
 }

--- a/frontend/src/assets/cs2-pattern.svg
+++ b/frontend/src/assets/cs2-pattern.svg
@@ -1,0 +1,17 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <g id="cs2-mark">
+      <path d="M26 18C16.0589 18 8 26.0589 8 36C8 45.9411 16.0589 54 26 54H44V46H26C20.4772 46 16 41.5228 16 36C16 30.4772 20.4772 26 26 26H44V18H26Z" fill="currentColor"/>
+      <path d="M78 18C68 18 60 23 60 30C60 35 63.5 38.5 69 41L76 44.5C79 46 82 47.5 82 50.5C82 54 78.5 56 72.5 56C67.5 56 62.5 54.5 58 52V60C62.5 62 67.5 63 72.5 63C83.5 63 90 57.5 90 50.5C90 44.5 86.5 40.5 80.5 37.5L74.5 34.5C71.5 33 69.5 31.5 69.5 29.5C69.5 26.5 73 25 78 25C82.5 25 87 26.5 91 28V20C86.5 18.5 82 18 78 18Z" fill="currentColor"/>
+      <circle cx="118" cy="24" r="6" fill="currentColor"/>
+      <rect x="114" y="32" width="8" height="20" rx="3" fill="currentColor"/>
+      <path d="M121 36L145 30C147 29.5 148.5 31.5 147.5 33L135.5 38L141.5 52L136.5 54.5L130.5 41.5L126.5 52L121 51L125.5 39L115 44L112.5 39.5L125 33.5C127 32.5 129 32 131 32.5L121 36Z" fill="currentColor"/>
+    </g>
+  </defs>
+  <g fill="#1D2343" fill-opacity="0.65">
+    <use href="#cs2-mark" />
+    <use href="#cs2-mark" x="-40" y="80" transform="scale(0.8)" />
+    <use href="#cs2-mark" x="60" y="78" transform="scale(0.9)" />
+    <use href="#cs2-mark" x="90" y="-8" transform="scale(0.7)" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- expand the dashboard containers to better use the full viewport width and add breathing room between cards
- apply a subtle CS2-inspired repeating background texture and refreshed hero styling
- adjust responsive breakpoints so the workspace and report sections stack cleanly on mobile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68ea483e88324965a23f995032bff