### PR TITLE
Add form-encoded fallback for webhook POST and reuse built payload

### DIFF
--- a/server.js
+++ b/server.js
@@ -1146,12 +1146,23 @@ function buildWebhookPayload(job, stage, extra = {}) {
 async function notifyWebhook(job, stage, payload = {}) {
   const url = job.webhookUrl || process.env.NOTIFY_WEBHOOK_URL;
   if (!url) return;
+  const bodyPayload = buildWebhookPayload(job, stage, payload);
   try {
-    const r = await fetch(url, {
+    let r = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(buildWebhookPayload(job, stage, payload)),
+      body: JSON.stringify(bodyPayload),
     });
+
+    if (r.status === 415) {
+      const fallbackBody = new URLSearchParams({ payload: JSON.stringify(bodyPayload) }).toString();
+      r = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: fallbackBody,
+      });
+    }
+
     if (!r.ok) {
       throw new Error(`Webhook retornou ${r.status}`);
     }


### PR DESCRIPTION
### Motivation
- Ensure webhook deliveries succeed for endpoints that reject `application/json` by retrying as `application/x-www-form-urlencoded`, and avoid rebuilding the payload twice.

### Description
- Compute the webhook body once using `buildWebhookPayload` and store it in a `bodyPayload` variable used for requests. 
- Change the initial fetch to use a mutable `let r` so the request can be retried. 
- If the webhook responds with status `415`, retry the POST with `Content-Type: application/x-www-form-urlencoded` using `URLSearchParams` with a `payload` field containing the JSON string. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5e15f3088324871b9e6458a8f6d1)