### PR TITLE
Refine Art Cases frontend UX feedback and branding

### DIFF
--- a/frontend/public/assets/logo-artcases.svg
+++ b/frontend/public/assets/logo-artcases.svg
@@ -1,0 +1,21 @@
+<svg width="1200" height="320" viewBox="0 0 1200 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(40,30)">
+    <path d="M20 165L175 115L330 165L175 215L20 165Z" fill="#11172A" stroke="#F59C2A" stroke-width="10"/>
+    <path d="M20 165V245L175 295V215L20 165Z" fill="#0E1424" stroke="#F59C2A" stroke-width="10"/>
+    <path d="M330 165V245L175 295V215L330 165Z" fill="#0A1020" stroke="#F59C2A" stroke-width="10"/>
+    <path d="M20 165L95 60L255 40L330 100" stroke="#F59C2A" stroke-width="10" stroke-linecap="round"/>
+    <path d="M95 60L175 80L330 100" stroke="#72D2F4" stroke-width="9" stroke-linecap="round"/>
+    <path d="M115 145L175 115L235 145L175 175L115 145Z" fill="#63CCE9"/>
+    <path d="M115 145V205L175 235V175L115 145Z" fill="#1A87BF"/>
+    <path d="M235 145V205L175 235V175L235 145Z" fill="#0F5D9C"/>
+    <path d="M175 175V235" stroke="#B8EEFF" stroke-width="4"/>
+    <g fill="#FFB247">
+      <path d="M266 95L274 111L290 119L274 127L266 143L258 127L242 119L258 111L266 95Z"/>
+      <circle cx="293" cy="145" r="6"/>
+      <circle cx="241" cy="144" r="4"/>
+      <circle cx="230" cy="118" r="4"/>
+    </g>
+  </g>
+  <text x="450" y="220" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="140" font-weight="700" fill="#72D2F4">Art</text>
+  <text x="640" y="220" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="140" font-weight="700" fill="#F59C2A">Cases</text>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -20,7 +20,7 @@ body { margin: 0; font-family: Inter, system-ui, sans-serif; background: radial-
 }
 .sidebar:hover { width: 240px; }
 .brand-mini { display: flex; align-items: center; gap: 10px; overflow: hidden; }
-.logo-mark { width: 36px; height: 36px; border-radius: 10px; background: linear-gradient(135deg,#ffb15f,var(--accent)); display:grid; place-items:center; font-weight:700; color:#1c120a; }
+.brand-copy { display: flex; flex-direction: column; }
 .brand-mini small, .brand-mini strong, .label { white-space: nowrap; opacity: 0; transition: opacity .15s; }
 .sidebar:hover .brand-mini small, .sidebar:hover .brand-mini strong, .sidebar:hover .label { opacity: 1; }
 .sidebar-nav { display: flex; flex-direction: column; gap: 6px; }
@@ -37,6 +37,12 @@ body { margin: 0; font-family: Inter, system-ui, sans-serif; background: radial-
 .title-wrap p { margin: 2px 0 0; color: var(--muted); }
 .header-chips { display: flex; gap: 10px; align-items: center; }
 
+.app-logo { display: block; width: auto; height: 42px; }
+.app-logo-header { height: 46px; }
+.logo-crop { overflow: hidden; border-radius: 10px; flex: 0 0 auto; }
+.logo-crop-sidebar { width: 38px; height: 38px; }
+.logo-crop-sidebar .app-logo { height: 38px; transform: translateX(-2px); }
+
 .workspace { display: flex; flex-direction: column; gap: 16px; }
 .metrics-row { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 12px; }
 .metric { background: var(--panel); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 12px; display:flex; flex-direction:column; gap:6px; }
@@ -51,18 +57,29 @@ textarea, input[type='url'] { width: 100%; background: #0c1120; color: var(--tex
 .button-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
 button { border: 1px solid transparent; border-radius: 10px; padding: 10px 12px; cursor: pointer; }
 .primary-btn { background: var(--accent); color: #1b1107; font-weight: 700; }
+.primary-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: #555c6f;
+  color: #d7dbe7;
+  border-color: transparent;
+  box-shadow: none;
+}
 .secondary-btn { background: #24304a; color: var(--text); }
 .ghost-btn { background: transparent; border-color: rgba(255,255,255,.2); color: var(--muted); }
 .ghost-btn:hover { color: #fff; border-color: rgba(255,255,255,.4); }
+button:disabled:hover { transform: none; border-color: transparent; }
 
 .log-toolbar { display: flex; justify-content: flex-end; gap: 8px; margin-bottom: 10px; }
 .log-stream { max-height: 520px; overflow: auto; display: flex; flex-direction: column; gap: 8px; }
 .log-entry { background: var(--panel); border-left: 3px solid #4f88ff; border-radius: 8px; padding: 8px 10px; display: grid; grid-template-columns: 92px 1fr; gap: 10px; }
 .log-entry span { color: var(--muted); font-size: 12px; }
 .log-entry p { margin: 0; }
-.log-warning { border-left-color: #ffd166; }
-.log-error { border-left-color: var(--err); }
-.log-success { border-left-color: var(--ok); }
+.log-info { border-left-color: #4f88ff; color: #b8c6ff; }
+.log-warning { border-left-color: #ffa94d; color: #ffa94d; }
+.log-error { border-left-color: #ff5c5c; color: #ff7a7a; }
+.log-success { border-left-color: #3bd671; color: #65e28f; }
+.log-info p, .log-warning p, .log-error p, .log-success p { color: inherit; }
 
 .status-indicator { display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 999px; background: rgba(255,255,255,.06); font-size: 12px; }
 .status-pulse { width: 8px; height: 8px; border-radius: 999px; background: #8f9bbc; }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,25 @@ function extractUniqueSteamIds(value) {
   return Array.from(unique);
 }
 
+function inferLogLevel(entry) {
+  const explicitLevel = String(entry?.level || entry?.type || '').toLowerCase();
+  if (['success', 'error', 'warning', 'info'].includes(explicitLevel)) {
+    return explicitLevel;
+  }
+
+  const message = String(entry?.message || '').toLowerCase();
+  if (/error|falha|failed|failure|not found|inválid|inválida/.test(message)) {
+    return 'error';
+  }
+  if (/vac|warn|warning|ban|indisponível|unavailable|rate limit/.test(message)) {
+    return 'warning';
+  }
+  if (/success|sucesso|avaliado|processed|concluído|valid/.test(message)) {
+    return 'success';
+  }
+  return 'info';
+}
+
 function App() {
   const [steamIds, setSteamIds] = useState('');
   const [logs, setLogs] = useState([]);
@@ -1460,8 +1479,10 @@ function App() {
     <div className="app-shell">
       <aside className="sidebar">
         <div className="brand-mini">
-          <span className="logo-mark">AC</span>
-          <div>
+          <div className="logo-crop logo-crop-sidebar" aria-hidden="true">
+            <img src="/assets/logo-artcases.svg" alt="" className="app-logo" />
+          </div>
+          <div className="brand-copy">
             <strong>Art Cases</strong>
             <small>Control</small>
           </div>
@@ -1491,10 +1512,10 @@ function App() {
       <div className="main-shell">
         <header className="top-header surface">
           <div className="title-wrap">
-            <span className="logo-mark">AC</span>
+            <img src="/assets/logo-artcases.svg" alt="Art Cases logo" className="app-logo app-logo-header" />
             <div>
               <h1>Art Cases</h1>
-              <p>Steam inventory analysis workspace.</p>
+              <p>Steam Inventory Monitor</p>
             </div>
           </div>
           <div className="header-chips">
@@ -1542,7 +1563,14 @@ function App() {
                   </details>
 
                   <div className="button-row">
-                    <button type="submit" className="primary-btn" disabled={isJobActive || isStoppingJob || !steamIds.trim() || steamIdLimitExceeded}>Start Analysis</button>
+                    <button
+                      type="submit"
+                      className="primary-btn"
+                      disabled={isJobActive || isStoppingJob || !steamIds.trim() || steamIdLimitExceeded}
+                      title={isJobActive ? 'Analysis already running' : 'Start analysis'}
+                    >
+                      {isJobActive ? 'Analysis Running…' : 'Start Analysis'}
+                    </button>
                     <button type="button" className="secondary-btn" onClick={isPaused ? handleResumeJob : handlePauseJob} disabled={!canControlJob}>{isPaused ? 'Retomar' : 'Pause'}</button>
                     <button type="button" className="ghost-btn" onClick={handleStopJob} disabled={!canControlJob || isStoppingJob}>{isStoppingJob ? 'Finalizando…' : 'Finalize'}</button>
                   </div>
@@ -1564,7 +1592,7 @@ function App() {
                     <div className="empty-state">Logs will appear here after start.</div>
                   ) : (
                     logs.map((entry, index) => (
-                      <article key={`${entry.timestamp || 'log'}-${index}`} className={`log-entry log-${entry.level || 'info'}`}>
+                      <article key={`${entry.timestamp || 'log'}-${index}`} className={`log-entry log-${inferLogLevel(entry)}`}>
                         <span>{entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString('pt-BR') : '--:--:--'}</span>
                         <p>{entry.message || 'Evento recebido'}</p>
                       </article>


### PR DESCRIPTION
### Motivation
- Improve user feedback so the `Start Analysis` CTA is unmistakably disabled and non-clickable while a job is active.  
- Restore color-coded log semantics so operators can scan large logs quickly for success, warning and error events.  
- Add visual brand identity by integrating the Art Cases logo in the header and sidebar while keeping the existing retractable sidebar behavior.  

### Description
- Added an `inferLogLevel` helper and switched log rendering to use `log-{level}` classes derived from either explicit payload fields or message content so entries map to `success`, `warning`, `error`, or `info`.  
- Restored and styled color-coded log classes in `frontend/src/App.css` (`.log-success`, `.log-error`, `.log-warning`, `.log-info`) to provide distinct border and text color semantics.  
- Updated the analysis CTA in `frontend/src/App.jsx` to surface a disabled state when `isJobActive` (`isProcessing || isPaused || isHydratingJob`) and display a contextual label/title (`Analysis Running…` / `Start Analysis`).  
- Added a muted visual treatment for disabled primary buttons in `frontend/src/App.css` (reduced `opacity`, `cursor: not-allowed`, muted background, removed hover affordances).  
- Integrated a new logo asset at `frontend/public/assets/logo-artcases.svg` and placed it in both the top header and the sidebar branding region with accompanying CSS (`.app-logo`, `.logo-crop`, `.logo-crop-sidebar`) to preserve collapsed/expanded behavior.  
- No backend logic, API calls, report generation, or processing pipeline code was changed.  

### Testing
- Ran production build with `npm run build` in `frontend` and the build completed successfully.  
- Started the dev server (`vite`) and captured a Playwright screenshot to validate the UI integration and visual states.  
- Ran `npm run lint` and it failed due to pre-existing `no-unused-vars` errors in `frontend/src/App.jsx` that are unrelated to these changes; lint errors were not introduced by this patch.  

Files changed: `frontend/src/App.jsx`, `frontend/src/App.css`, `frontend/public/assets/logo-artcases.svg`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2325b66148324b4a82ac442170e79)