### PR TITLE
Translate UI to PT-BR and apply HTML report profile filters

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Art Cases</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1484,16 +1484,16 @@ function App() {
           </div>
           <div className="brand-copy">
             <strong>Art Cases</strong>
-            <small>Control</small>
+            <small>Controle</small>
           </div>
         </div>
         <nav className="sidebar-nav">
           {[
-            ['analysis', '⌂', 'Main Analysis'],
-            ['friends', '👥', 'Friends List'],
-            ['reports', '🧾', 'Saved Reports'],
-            ['history', '🗂', 'Processed IDs History'],
-            ['settings', '⚙', 'Settings'],
+            ['analysis', '⌂', 'Análise principal'],
+            ['friends', '👥', 'Lista de amigos'],
+            ['reports', '🧾', 'Relatórios salvos'],
+            ['history', '🗂', 'Histórico de IDs processadas'],
+            ['settings', '⚙', 'Configurações'],
           ].map(([key, icon, label]) => (
             <button
               key={key}
@@ -1506,20 +1506,20 @@ function App() {
             </button>
           ))}
         </nav>
-        <div className="sidebar-status">Backend connected</div>
+        <div className="sidebar-status">Backend conectado</div>
       </aside>
 
       <div className="main-shell">
         <header className="top-header surface">
           <div className="title-wrap">
-            <img src="/assets/logo-artcases.svg" alt="Art Cases logo" className="app-logo app-logo-header" />
+            <img src="/assets/logo-artcases.svg" alt="Logo da Art Cases" className="app-logo app-logo-header" />
             <div>
               <h1>Art Cases</h1>
-              <p>Steam Inventory Monitor</p>
+              <p>Monitor de inventário Steam</p>
             </div>
           </div>
           <div className="header-chips">
-            {currentJobId && <span className="job-pill">Job {currentJobId.slice(0, 8)}…</span>}
+            {currentJobId && <span className="job-pill">Execução {currentJobId.slice(0, 8)}…</span>}
             <span className={`status-indicator status-${statusTone}`}>
               <span className="status-pulse" />
               {statusLabel}
@@ -1530,10 +1530,10 @@ function App() {
         {activeTab === 'analysis' && (
           <main className="workspace">
             <section className="metrics-row">
-              <article className="metric"><span>Processed IDs</span><strong>{processedTotal.toLocaleString('pt-BR')}</strong></article>
-              <article className="metric"><span>Evaluated Inventories</span><strong>{jobResult?.successCount ?? 0}</strong></article>
-              <article className="metric"><span>VAC Blocked</span><strong>{jobResult?.totals?.vacBanned ?? 0}</strong></article>
-              <article className="metric"><span>Failures</span><strong>{(jobResult?.totals?.steamErrors ?? 0) + (jobResult?.totals?.montugaErrors ?? 0)}</strong></article>
+              <article className="metric"><span>IDs processadas</span><strong>{processedTotal.toLocaleString('pt-BR')}</strong></article>
+              <article className="metric"><span>Inventários avaliados</span><strong>{jobResult?.successCount ?? 0}</strong></article>
+              <article className="metric"><span>VAC bloqueados</span><strong>{jobResult?.totals?.vacBanned ?? 0}</strong></article>
+              <article className="metric"><span>Falhas</span><strong>{(jobResult?.totals?.steamErrors ?? 0) + (jobResult?.totals?.montugaErrors ?? 0)}</strong></article>
             </section>
 
             <section className="analysis-layout">
@@ -1567,29 +1567,29 @@ function App() {
                       type="submit"
                       className="primary-btn"
                       disabled={isJobActive || isStoppingJob || !steamIds.trim() || steamIdLimitExceeded}
-                      title={isJobActive ? 'Analysis already running' : 'Start analysis'}
+                      title={isJobActive ? 'Análise já em execução' : 'Iniciar análise'}
                     >
-                      {isJobActive ? 'Analysis Running…' : 'Start Analysis'}
+                      {isJobActive ? 'Análise em execução…' : 'Iniciar análise'}
                     </button>
-                    <button type="button" className="secondary-btn" onClick={isPaused ? handleResumeJob : handlePauseJob} disabled={!canControlJob}>{isPaused ? 'Retomar' : 'Pause'}</button>
-                    <button type="button" className="ghost-btn" onClick={handleStopJob} disabled={!canControlJob || isStoppingJob}>{isStoppingJob ? 'Finalizando…' : 'Finalize'}</button>
+                    <button type="button" className="secondary-btn" onClick={isPaused ? handleResumeJob : handlePauseJob} disabled={!canControlJob}>{isPaused ? 'Retomar' : 'Pausar'}</button>
+                    <button type="button" className="ghost-btn" onClick={handleStopJob} disabled={!canControlJob || isStoppingJob}>{isStoppingJob ? 'Finalizando…' : 'Finalizar execução'}</button>
                   </div>
                   <div className="button-row utility-row">
-                    <button type="button" className="ghost-btn" onClick={resetInterface} disabled={isJobActive || isStoppingJob}>Clear</button>
-                    <button type="button" className="ghost-btn" onClick={handleGeneratePartialReport} disabled={!isPaused || !currentJobId || isStoppingJob}>Partial Report</button>
-                    <button type="button" className="ghost-btn" onClick={handleDownloadHistory} disabled={(isProcessing && !isPaused) || isStoppingJob}>Download 24h</button>
+                    <button type="button" className="ghost-btn" onClick={resetInterface} disabled={isJobActive || isStoppingJob}>Limpar interface</button>
+                    <button type="button" className="ghost-btn" onClick={handleGeneratePartialReport} disabled={!isPaused || !currentJobId || isStoppingJob}>Gerar relatório parcial</button>
+                    <button type="button" className="ghost-btn" onClick={handleDownloadHistory} disabled={(isProcessing && !isPaused) || isStoppingJob}>Baixar histórico (24h)</button>
                   </div>
                 </form>
               </div>
 
               <div className="surface log-card">
                 <div className="log-toolbar">
-                  {activeShareLink && <button type="button" className="ghost-btn" onClick={handleCopyShareLink}>Copy tracking link</button>}
-                  {jobResult?.reportHtml && <button type="button" className="ghost-btn" onClick={handleDownloadReport}>Open report</button>}
+                  {activeShareLink && <button type="button" className="ghost-btn" onClick={handleCopyShareLink}>Copiar link de acompanhamento</button>}
+                  {jobResult?.reportHtml && <button type="button" className="ghost-btn" onClick={handleDownloadReport}>Abrir relatório</button>}
                 </div>
                 <div className="log-stream" ref={logContainerRef}>
                   {logs.length === 0 ? (
-                    <div className="empty-state">Logs will appear here after start.</div>
+                    <div className="empty-state">Os logs aparecerão aqui após o início.</div>
                   ) : (
                     logs.map((entry, index) => (
                       <article key={`${entry.timestamp || 'log'}-${index}`} className={`log-entry log-${inferLogLevel(entry)}`}>
@@ -1604,20 +1604,20 @@ function App() {
 
             <section className="surface reports-compact">
               <div className="section-head">
-                <h3>Saved reports</h3>
-                <button type="button" className="ghost-btn" onClick={() => setActiveTab('reports')}>Open module</button>
+                <h3>Relatórios salvos</h3>
+                <button type="button" className="ghost-btn" onClick={() => setActiveTab('reports')}>Abrir módulo</button>
               </div>
               <div className="compact-list">
                 {reportHistory.slice(0, 3).map((entry) => (
                   <div className="compact-item" key={entry.id}>
                     <div>
-                      <strong>{entry.partial ? 'Partial' : 'Final'} report</strong>
+                      <strong>Relatório {entry.partial ? 'parcial' : 'final'}</strong>
                       <span>{formatHistoryTimestamp(entry.generatedAt)}</span>
                     </div>
-                    <button type="button" className="ghost-btn" onClick={() => handleSelectHistory(entry.id)}>View</button>
+                    <button type="button" className="ghost-btn" onClick={() => handleSelectHistory(entry.id)}>Visualizar</button>
                   </div>
                 ))}
-                {reportHistory.length === 0 && <div className="empty-state">No saved reports yet.</div>}
+                {reportHistory.length === 0 && <div className="empty-state">Ainda não há relatórios salvos.</div>}
               </div>
             </section>
           </main>
@@ -1641,31 +1641,31 @@ function App() {
         {activeTab === 'reports' && (
           <section className="surface module-page">
             <div className="section-head">
-              <h2>Saved Reports</h2>
-              <button type="button" className="ghost-btn" onClick={handleClearHistory} disabled={reportHistory.length === 0}>Clear history</button>
+              <h2>Relatórios salvos</h2>
+              <button type="button" className="ghost-btn" onClick={handleClearHistory} disabled={reportHistory.length === 0}>Limpar histórico</button>
             </div>
             <div className="compact-list">
               {reportHistory.map((entry) => (
                 <div className="compact-item" key={entry.id}>
                   <div>
-                    <strong>{entry.partial ? 'Partial' : 'Final'} - {entry.jobId}</strong>
+                    <strong>{entry.partial ? 'Parcial' : 'Final'} - {entry.jobId}</strong>
                     <span>{formatHistoryTimestamp(entry.generatedAt)}</span>
                   </div>
                   <div className="button-row">
-                    <button type="button" className="ghost-btn" onClick={() => handleSelectHistory(entry.id)}>Open</button>
-                    <button type="button" className="ghost-btn" onClick={() => handleDownloadHistoryEntry(entry)}>Download</button>
+                    <button type="button" className="ghost-btn" onClick={() => handleSelectHistory(entry.id)}>Abrir</button>
+                    <button type="button" className="ghost-btn" onClick={() => handleDownloadHistoryEntry(entry)}>Baixar</button>
                   </div>
                 </div>
               ))}
             </div>
-            {activeHistoryEntry?.reportHtml && <iframe title="Report preview" srcDoc={activeHistoryEntry.reportHtml} className="history-frame" sandbox="allow-same-origin allow-scripts" />}
+            {activeHistoryEntry?.reportHtml && <iframe title="Prévia do relatório" srcDoc={activeHistoryEntry.reportHtml} className="history-frame" sandbox="allow-same-origin allow-scripts" />}
           </section>
         )}
 
         {activeTab === 'history' && (
           <section className="surface module-page">
             <div className="section-head">
-              <h2>Processed IDs History</h2>
+              <h2>Histórico de IDs processadas</h2>
               <button type="button" className="ghost-btn" onClick={refreshProcessedRegistry} disabled={processedRegistry.isLoading}>{processedRegistry.isLoading ? 'Atualizando…' : 'Atualizar'}</button>
             </div>
             <p>Total: {processedTotal.toLocaleString('pt-BR')} IDs</p>
@@ -1679,10 +1679,10 @@ function App() {
 
         {activeTab === 'settings' && (
           <section className="surface module-page">
-            <h2>Settings</h2>
-            <label className="field-label" htmlFor="settings-webhook">Webhook URL</label>
+            <h2>Configurações</h2>
+            <label className="field-label" htmlFor="settings-webhook">URL do webhook</label>
             <input id="settings-webhook" type="url" value={webhookUrl} onChange={(event) => setWebhookUrl(event.target.value)} />
-            <p className="field-hint">Optional external notifications endpoint.</p>
+            <p className="field-hint">Endpoint opcional para notificações externas.</p>
           </section>
         )}
       </div>

--- a/server.js
+++ b/server.js
@@ -607,6 +607,42 @@ function statusBadgeClass(status) {
   }
 }
 
+
+function isProfileOnline(profile) {
+  if (!profile || typeof profile !== 'object') {
+    return false;
+  }
+
+  if (profile.inGame) {
+    return true;
+  }
+
+  const personaState = Number(profile.personaState);
+  if (Number.isFinite(personaState)) {
+    return personaState > 0;
+  }
+
+  const label = String(profile.personaStateLabel || '').toLowerCase();
+  return label.includes('online') || label.includes('jogando');
+}
+
+function canRenderProfileInHtml(profile) {
+  if (!profile || typeof profile !== 'object') {
+    return false;
+  }
+
+  if (isProfileOnline(profile)) {
+    return false;
+  }
+
+  const inventoryValue = Number(profile.totalValueBRL);
+  if (!Number.isFinite(inventoryValue)) {
+    return false;
+  }
+
+  return inventoryValue >= 1500 && inventoryValue <= 8000;
+}
+
 function generateReportHtml({ job, results, totals, partial, generatedAt }) {
   const rows = results.map((profile, index) => {
     const amount = typeof profile.totalValueBRL === 'number'
@@ -637,7 +673,7 @@ function generateReportHtml({ job, results, totals, partial, generatedAt }) {
         </td>
         <td>
           <a href="${steamProfileUrl(profile.id)}" target="_blank" rel="noopener noreferrer" class="name-link">
-            ${escapeHtml(profile.name ?? 'N/A')}
+            ${escapeHtml(profile.name ?? 'N/D')}
           </a>
         </td>
         <td><span class="state-pill ${personaClass}">${escapeHtml(personaLabel)}</span></td>
@@ -873,7 +909,7 @@ function generateReportHtml({ job, results, totals, partial, generatedAt }) {
       <div class="report-shell">
         <div class="report-card">
           <h1>${escapeHtml(title)}</h1>
-          <p class="meta">Gerado em ${escapeHtml(generatedLabel)} • Job ${escapeHtml(job.id)}</p>
+          <p class="meta">Gerado em ${escapeHtml(generatedLabel)} • Execução ${escapeHtml(job.id)}</p>
           <div class="summary-grid">
             ${summaryTiles}
           </div>
@@ -925,7 +961,8 @@ async function buildReport(job, { partial = false } = {}) {
     }
     return valueB - valueA;
   });
-  const reportHtml = generateReportHtml({ job, results: sortedResults, totals, partial, generatedAt });
+  const filteredResults = sortedResults.filter((profile) => canRenderProfileInHtml(profile));
+  const reportHtml = generateReportHtml({ job, results: filteredResults, totals, partial, generatedAt });
 
   return {
     jobId: job.id,
@@ -1246,7 +1283,7 @@ function failJob(jobId, msg) {
 async function fetchSteamProfile(jobId, steamId) {
   const info = {
     id: steamId,
-    name: 'N/A',
+    name: 'N/D',
     vacBanned: false,
     gameBans: 0,
     status: 'ready',
@@ -1770,7 +1807,7 @@ function buildHistoryHtml(entries) {
       <header>
         <h2>Registro ${index + 1} • ${escapeHtml(currentDateTimeLabel(entry.generatedAt))}</h2>
         <span class="badge ${entry.partial ? 'badge-partial' : 'badge-final'}">${entry.partial ? 'Prévia' : 'Final'}</span>
-        <span class="job-id">Job ${escapeHtml(entry.jobId || 'desconhecido')}</span>
+        <span class="job-id">Execução ${escapeHtml(entry.jobId || 'desconhecido')}</span>
       </header>
       ${downloadMarkup}
       <div class="history-metrics">


### PR DESCRIPTION
### Motivation
- Make the user-facing interface fully Portuguese (PT-BR) and keep the UI wording consistent and professional.
- Reduce noise in generated HTML reports by excluding online accounts and inventories outside the 1500–8000 BRL inclusive range.

### Description
- Translate visible UI strings from English to PT-BR in `frontend/src/App.jsx` and set the app `lang` and `<title>` in `frontend/index.html` to `pt-BR`/`Art Cases`.
- Add `isProfileOnline(profile)` and `canRenderProfileInHtml(profile)` helper functions to `server.js` to detect online status and inventory value eligibility.
- Apply the filter in `buildReport` to pass only `filteredResults` to `generateReportHtml`, so excluded profiles are removed from the final HTML output (not hidden by CSS).
- Adjust a few user-facing report strings in `server.js` (e.g. job label → `Execução`, name fallback `N/D`) to keep generated HTML fully localized.

### Testing
- Ran frontend linter with `npm --prefix frontend run lint`, which failed due to preexisting unused-variable issues in the project unrelated to these changes (lint errors were not introduced by this PR).
- Built production frontend with `npm run build`, which completed successfully.
- Started dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and verified UI visually; an automated screenshot was produced for validation (`artifacts/ui-ptbr.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b239e48060832489b0d9af681bba7c)