### PR TITLE
Add compatibility for legacy `/friends-list` and normalize friends-list handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -1485,8 +1485,20 @@ async function startJob(jobId, ids, webhookUrl, options = {}) {
 }
 
 // ----------------- Rotas -----------------
-app.post('/friends/list', async (req, res) => {
-  const input = Array.isArray(req.body?.steamIds) ? req.body.steamIds : [];
+function parseFriendsListInput(body = {}) {
+  if (Array.isArray(body?.steamIds)) {
+    return body.steamIds;
+  }
+
+  if (typeof body?.steam_id === 'string') {
+    return [body.steam_id];
+  }
+
+  return [];
+}
+
+async function handleFriendsListRequest(req, res, { legacyResponse = false } = {}) {
+  const input = parseFriendsListInput(req.body);
   const entries = input
     .map((value) => {
       const raw = String(value ?? '').trim();
@@ -1498,6 +1510,11 @@ app.post('/friends/list', async (req, res) => {
     .filter(({ raw }) => raw.length > 0);
 
   if (entries.length === 0) {
+    if (legacyResponse) {
+      res.status(400).json({ success: false, message: 'Informe pelo menos uma SteamID64.' });
+      return;
+    }
+
     res.status(400).json({ error: 'Informe pelo menos uma SteamID64.' });
     return;
   }
@@ -1521,11 +1538,43 @@ app.post('/friends/list', async (req, res) => {
       }
     }));
 
+    if (legacyResponse) {
+      const primary = results[0] || null;
+      if (!primary || primary.error) {
+        res.status(400).json({
+          success: false,
+          message: primary?.error || 'Não foi possível carregar a lista de amigos.',
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        count: primary.friendCount,
+        rawIds: primary.friends,
+      });
+      return;
+    }
+
     res.json({ results });
   } catch (error) {
     console.error('Falha ao consultar listas de amigos da Steam.', error);
+
+    if (legacyResponse) {
+      res.status(500).json({ success: false, message: 'Não foi possível consultar as listas de amigos no momento.' });
+      return;
+    }
+
     res.status(500).json({ error: 'Não foi possível consultar as listas de amigos no momento.' });
   }
+}
+
+app.post('/friends/list', async (req, res) => {
+  await handleFriendsListRequest(req, res);
+});
+
+app.post('/friends-list', async (req, res) => {
+  await handleFriendsListRequest(req, res, { legacyResponse: true });
 });
 
 app.post('/process', async (req, res) => {


### PR DESCRIPTION
### Motivation
- The frontend used two different friends-list payloads/endpoints (`/friends/list` with `steamIds` and legacy `/friends-list` with `steam_id`) which caused friend retrieval to break on the older page. 
- Provide a single server-side handler that accepts both payload shapes and returns the expected schema for each client to restore functionality.

### Description
- Added `parseFriendsListInput` to normalize incoming payloads and accept either `steamIds` (array) or `steam_id` (legacy single string). 
- Introduced `handleFriendsListRequest` to centralize the friends lookup logic and to optionally emit legacy-style responses when called with `legacyResponse: true`. 
- Exposed two routes: `POST /friends/list` (current React UI) and `POST /friends-list` (legacy page), where the legacy route returns the legacy response schema (`success`, `count`, `rawIds`, `message`). 
- Adjusted error handling so both modes return appropriate JSON shapes for empty payloads and server errors.

### Testing
- Verified syntax with `node --check server.js`, which passed. 
- Launched the server and tested both endpoints with `curl` using empty payloads to validate responses, where `POST /friends-list` returned legacy `400` JSON (`success:false`) and `POST /friends/list` returned current `400` JSON (`error`), both as expected. 
- No automated unit tests were modified or added; manual endpoint validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24c9a66dc8324801d40fcb82a2229)